### PR TITLE
Docker-compose setup - Try to run api-builder with docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ ning_1_8_scala_2_11/src
 .DS_STORE
 .idea/
 .idea_modules/
+db
 

--- a/Dockerfile_api
+++ b/Dockerfile_api
@@ -1,0 +1,6 @@
+FROM hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+RUN apt-get install screen
+WORKDIR /workdir
+COPY . .
+
+CMD sh start_api.sh

--- a/Dockerfile_app
+++ b/Dockerfile_app
@@ -1,0 +1,6 @@
+FROM hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+RUN apt-get install screen
+WORKDIR /workdir
+COPY . .
+
+CMD sh start_app.sh

--- a/RUN_WITH_DOCKER_COMPOSE.md
+++ b/RUN_WITH_DOCKER_COMPOSE.md
@@ -1,0 +1,11 @@
+Example how to run dev with docker-compose
+==========
+
+## Build 
+``docker-compose build``
+## Run
+``docker-compose run``
+
+## Try
+
+Go to: http://localhost:9000/login/dev

--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -1,9 +1,9 @@
 include "base.conf"
 
-db.default.url="jdbc:postgresql://localhost/apibuilderdb"
+db.default.url="jdbc:postgresql://db/apibuilderdb"
 db.default.url=${?CONF_DB_DEFAULT_URL}
 
-apibuilder.app.host="http://localhost:9000"
+apibuilder.app.host="http://app:9000"
 
 play.http.secret.key="development"
 

--- a/app/conf/application.conf
+++ b/app/conf/application.conf
@@ -1,7 +1,7 @@
 include "base.conf"
 
 play.http.secret.key="development"
-apibuilder.api.host="http://localhost:9001"
+apibuilder.api.host="http://api:9001"
 apibuilder.api.token="ZdRD61ODVPspeV8Wf18EmNuKNxUfjfROyJXtNJXj9GMMwrAxqi8I4aUtNAT6"
-apibuilder.app.host="http://localhost:9000"
+apibuilder.app.host="http://app:9000"
 apibuilder.github.oauth.client.id=60aafb7d025ff883bcc2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile_app
+    ports:
+      - "9000:9000"
+    depends_on:
+      - api
+    links:
+      - api
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile_api
+    ports:
+      - "9001:9001"
+    depends_on:
+      - db
+    links:
+      - db
+  db:
+    image: "flowcommerce/apibuilder-postgresql:latest"
+    ports:
+      - "5432:5432"
+    expose:
+      - 5432
+    volumes:
+      - ./db:/var/lib/postgresql/data

--- a/start_api.sh
+++ b/start_api.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sbt "project api" "runProd 9001"
+tail -f /dev/null

--- a/start_app.sh
+++ b/start_app.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sbt "project app" "runProd 9000"
+tail -f /dev/null


### PR DESCRIPTION
I created a docker-compose setup to test the apibuilder as self-hosted applictation from Docker.
I had few issues during try to run the apibuilder for testing:
- Dockerfiles are out-dated and I couldn't run them (missing update + missing configuration for that)
- I had to use an earlier version from history, as I experienced, after sbt 1.3 update I couldn't run the applications with sbt (there were some missing plugins issue )
- I wanted to run everything from Docker, so I created a basic docker-compose for it.

I don't have so many experience with Java or Scala, sbt and playframwork, so I think this solution is really hack now. My goal was to be able to run the apibuilder application from my Docker environment.